### PR TITLE
Auto-Publish Documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ script:
 notifications:
   email: false
   irc: chat.freenode.net#canon-dev
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ script:
 cache:
   directories:
   - node_modules
+after_success:
+  - scripts/deploy-documentation
 notifications:
   email: false
   irc: chat.freenode.net#canon-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js:
 script:
 - npm run build
 - npm run documentation
+cache:
+  directories:
+  - node_modules
 notifications:
   email: false
   irc: chat.freenode.net#canon-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
 - '0.10'
+before_script:
+- npm install -g npm
 script:
 - npm run build
 - npm run documentation -- --base-uri http://rackerlabs.github.io/canon-bootstrap/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - '0.10'
 script:
 - npm run build
-- npm run documentation
+- npm run documentation -- --base-uri http://rackerlabs.github.io/canon-bootstrap/
 cache:
   directories:
   - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,8 @@ cache:
 notifications:
   email: false
   irc: chat.freenode.net#canon-dev
+env:
+  global:
+  - secure: sbEm4bVUV6Iw3cWMh2MSGw/hHCLWvExj/INlfx2vdGvFJ1STdnPJXd8dL+gBbHOwSoCoJ7OIZJ56jirHCCW3ZOHNGrJHUSHR3E47MA8HhHWZavvwCR4RkAvizkpFn+E43i5CweoKXzfXmLZSRpYeNa6j+PgNn+nQGIbC7huKh9A=
+  - secure: gH+Zm0ScQaCwF1GD7S2CI7yVoyPP8lAiNKvFFgLi/sx/Qo9gpTy2Hfoev3M3Jp9Nz4jVXaOhc+8wM9IHL/MWs0gWf+R3no4Yw/FB2hh6b3/oVPjsWeqwJKfXC/k7MPqud2u1Cm0qWHR0DWlxi1OrPw5P+ISV7qsKPKG+8gbgMtA=
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
 - '0.10'
-- '0.11'
 script:
 - npm run build
 - npm run documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: node_js
 node_js:
 - '0.10'
 - '0.11'
-script: npm run build
+script:
+- npm run build
+- npm run documentation
 notifications:
   email: false
   irc: chat.freenode.net#canon-dev

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -6,7 +6,9 @@ var minifyCSS = require('gulp-minify-css');
 var less = require('gulp-less');
 var sourcemaps = require('gulp-sourcemaps');
 var concat = require('gulp-concat');
-
+var argv = require('yargs')
+  .default('baseUri', '/')
+  .argv;
 
 function error(e) {
   util.log(e.toString());
@@ -84,6 +86,7 @@ gulp.task('documentation', ['build'], function (done) {
   async.series({
     metalsmith: function (done) {
       metalsmith(join(__dirname, 'docs'))
+        .metadata({ baseUri: argv.baseUri })
         .use(markdown())
         .use(templates('handlebars'))
         .build(done);

--- a/docs/templates/documentation.html
+++ b/docs/templates/documentation.html
@@ -9,8 +9,10 @@
   <meta name="description" content="{{ description }}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="stylesheet" href="/css/canon-bootstrap.css">
-  <link rel="stylesheet" href="/documentation.css">
+  <base href="{{ baseUri }}">
+
+  <link rel="stylesheet" href="css/canon-bootstrap.css">
+  <link rel="stylesheet" href="documentation.css">
 </head>
 <body data-spy="scroll" data-target="#sidebar">
   <header class="navbar navbar-utility navbar-inverse">
@@ -20,8 +22,8 @@
       </div>
       <nav>
         <ul class="nav navbar-nav">
-          <li class="active"><a href="/">Documentation</a></li>
-          <li><a href="/demo/">Demo</a></li>
+          <li class="active"><a href="">Documentation</a></li>
+          <li><a href="demo">Demo</a></li>
         </ul>
         <ul class="nav navbar-nav navbar-right">
           <li><a href="https://github.com/rackerlabs/canon-bootstrap">GitHub</a></li>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "handlebars": "^2.0.0",
     "metalsmith": "^1.0.1",
     "metalsmith-markdown": "^0.2.1",
-    "metalsmith-templates": "^0.6.0"
+    "metalsmith-templates": "^0.6.0",
+    "yargs": "^2.3.0"
   },
   "dependencies": {
     "bootstrap": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "build": "gulp build",
-    "start": "gulp server",
-    "doc": "gulp doc"
+    "documentation": "gulp documentation",
+    "start": "gulp server"
   },
   "devDependencies": {
     "async": "^0.9.0",

--- a/scripts/deploy-documentation
+++ b/scripts/deploy-documentation
@@ -14,11 +14,24 @@ error() {
   echo -e "\033[31;1m$1"
 }
 
-# Prevent builds to branches other than master.
-
 echo "==> Verifying build environment..."
 
-# Verify existence of environment variables.
+# Prevent builds to branches other than master.
+
+if [ -z "$GH_USER" ]; then
+  error "Environment variable GH_USER does not exist. Stopping deploy."
+  exit 1
+fi
+
+if [ -z "$GH_TOKEN" ]; then
+  error "Environment variable GH_TOKEN does not exist. Stopping deploy."
+  exit 1
+fi
+
+if [ -z "$TRAVIS_COMMIT" ]; then
+  error "Environment variable TRAVIS_COMMIT does not exist. Stopping deploy."
+  exit 1
+fi
 
 if [ ! -d $DOCUMENTATION ]; then
   error "Documentation does not exist. Stopping deploy."
@@ -43,5 +56,4 @@ git config user.email $GH_USER@rackspace.com
 git commit --message "docs(travis): publish documentation for $TRAVIS_COMMIT"
 git push origin gh-pages
 
-# Green
 success "Successfully published documentation for $TRAVIS_COMMIT!"

--- a/scripts/deploy-documentation
+++ b/scripts/deploy-documentation
@@ -6,6 +6,14 @@ BRANCH='gh-pages'
 REPOSITORY=`mktemp -d /tmp/canon-bootstrap.XXXXXX`
 DOCUMENTATION='docs/build/'
 
+success() {
+  echo -e "\033[32;1m$1"
+}
+
+error() {
+  echo -e "\033[31;1m$1"
+}
+
 # Prevent builds to branches other than master.
 
 echo "==> Verifying build environment..."
@@ -13,8 +21,7 @@ echo "==> Verifying build environment..."
 # Verify existence of environment variables.
 
 if [ ! -d $DOCUMENTATION ]; then
-  # Red
-  echo "Documentation does not exist. Failing deploy!"
+  error "Documentation does not exist. Stopping deploy."
   exit 1
 fi
 
@@ -26,9 +33,8 @@ echo "==> Pushing updated documentation to GitHub Pages..."
 cd $REPOSITORY
 
 if [ -z "$(git status --porcelain)" ]; then
-  # Green
-  echo "No documentation changes to publish!"
-  exit 0
+  success "No documentation changes to publish. Skipping deploy."
+  exit 1
 fi
 
 git add --all
@@ -38,4 +44,4 @@ git commit --message "docs(travis): publish documentation for $TRAVIS_COMMIT"
 git push origin gh-pages
 
 # Green
-echo "Successfully published documentation for $TRAVIS_COMMIT!"
+success "Successfully published documentation for $TRAVIS_COMMIT!"

--- a/scripts/deploy-documentation
+++ b/scripts/deploy-documentation
@@ -16,8 +16,6 @@ error() {
 
 echo "==> Verifying build environment..."
 
-# Prevent builds to branches other than master.
-
 if [ -z "$GH_USER" ]; then
   error "Environment variable GH_USER does not exist. Stopping deploy."
   exit 1
@@ -25,6 +23,11 @@ fi
 
 if [ -z "$GH_TOKEN" ]; then
   error "Environment variable GH_TOKEN does not exist. Stopping deploy."
+  exit 1
+fi
+
+if [ -z "$TRAVIS_BRANCH" ]; then
+  error "Environment variable TRAVIS_BRANCH does not exist. Stopping deploy."
   exit 1
 fi
 
@@ -45,9 +48,14 @@ rsync -rt --del --exclude=".git" $DOCUMENTATION $REPOSITORY
 echo "==> Pushing updated documentation to GitHub Pages..."
 cd $REPOSITORY
 
+if [ "$TRAVIS_BRANCH" != "master" ]; then
+  success "Not building master branch. Skipping deploy."
+  exit 0
+fi
+
 if [ -z "$(git status --porcelain)" ]; then
   success "No documentation changes to publish. Skipping deploy."
-  exit 1
+  exit 0
 fi
 
 git add --all

--- a/scripts/deploy-documentation
+++ b/scripts/deploy-documentation
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -e
+
+BRANCH='gh-pages'
+REPOSITORY=`mktemp -d /tmp/canon-bootstrap.XXXXXX`
+DOCUMENTATION='docs/build/'
+
+# Prevent builds to branches other than master.
+
+echo "==> Verifying build environment..."
+
+# Verify existence of environment variables.
+
+if [ ! -d $DOCUMENTATION ]; then
+  # Red
+  echo "Documentation does not exist. Failing deploy!"
+  exit 1
+fi
+
+echo "==> Syncing updated documentation..."
+git clone --branch $BRANCH https://$GH_TOKEN@github.com/rackerlabs/canon-bootstrap $REPOSITORY
+rsync -rt --del --exclude=".git" $DOCUMENTATION $REPOSITORY
+
+echo "==> Pushing updated documentation to GitHub Pages..."
+cd $REPOSITORY
+
+if [ -z "$(git status --porcelain)" ]; then
+  # Green
+  echo "No documentation changes to publish!"
+  exit 0
+fi
+
+git add --all
+git config user.name $GH_USER
+git config user.email $GH_USER@rackspace.com
+git commit --message "docs(travis): publish documentation for $TRAVIS_COMMIT"
+git push origin gh-pages
+
+# Green
+echo "Successfully published documentation for $TRAVIS_COMMIT!"


### PR DESCRIPTION
The purpose of this PR is to auto-publish Canon Bootstrap's documentation to GitHub Pages every time a commit is made to the master branch. This will make sure the published documentation is always up-to-date without human intervention.

To implement this feature, this PR introduces the following changes:

- Build documentation on every Travis build.
- Cache node_modules to speed up Travis builds.
- Execute on_success script that publishes to GitHub pages using a shell script.

In the future, I can see this being improved in a number of ways:

1. Only publish documentation to the root of `gh-pages` when a tag is pushed. This will synchronize documentation with official releases.
1. Provide archived versions of documentation for official releases at `releases/VERSION`.
1. When commits to master are made, push documentation to `builds/SHA` within `gh-pages` so documentation for master is also publicly available. We could also use the same approach for publishing/previewing documentation changes in a pull request, but it might result in a crazy number of pushes to `gh-pages`.