### PR TITLE
styles(dropdown) update default dropdown, inverse, primary

### DIFF
--- a/docs/templates/demo.html
+++ b/docs/templates/demo.html
@@ -43,6 +43,11 @@
                   Link
                 </a>
               </li>
+              <li>
+                <a href="#">
+                  Link <span class="dropdown-caption">With Caption</span>
+                </a>
+              </li>
               <li role="presentation" class="divider"></li>
               <li>
                 <a href="#">Log Out</a>

--- a/docs/templates/detail.html
+++ b/docs/templates/detail.html
@@ -43,6 +43,11 @@
                   Link
                 </a>
               </li>
+              <li>
+                <a href="#">
+                  Link <span class="dropdown-caption">With Caption</span>
+                </a>
+              </li>
               <li role="presentation" class="divider"></li>
               <li>
                 <a href="#">Log Out</a>
@@ -73,13 +78,17 @@
           <li><a href="#">Backup</a></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">More <span class="caret"></span></a>
-            <ul class="dropdown-menu" role="menu">
+            <ul class="dropdown-menu dropdown-primary" role="menu">
+              <li role="presentation" class="dropdown-header">Links</li>
               <li><a href="#">Action</a></li>
               <li><a href="#">Another action</a></li>
               <li><a href="#">Something else here</a></li>
-              <li class="divider"></li>
-              <li><a href="#">Separated link</a></li>
-              <li class="divider"></li>
+              <li><a href="#">External link <i class="fa fa-external-link"></i></a></li>
+              <li>
+                <a href="#">
+                  Link <span class="dropdown-caption">With Caption</span>
+                </a>
+              </li>
               <li><a href="#">One more separated link</a></li>
             </ul>
           </li>

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -1,9 +1,53 @@
+.dropdown-header {
+  font-size: 10px;
+  font-weight: bold;
+  margin-top: 10px;
+  padding: 0 7px;
+  text-transform: uppercase;
+
+  &:first-child {
+    margin-top: 0;
+  }
+}
+
+.dropdown-menu {
+  border-radius: 3px;
+  min-width: 130px;
+
+  > li > a {
+    padding: 0 7px;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+// .rs-dropdown-caption
+.dropdown-caption {
+  display: block;
+  color: #999;
+  font-family: @headings-font-family;
+  font-size: 12px;
+  font-weight: 200;
+  padding: 0;
+  text-decoration: none;
+}
+
 .dropdown-inverse.dropdown-menu {
   background-color: #333;
-  border: none;
-  border-radius: 3px;
 
-  & > li > a {
+  .dropdown-header,
+  > li > a {
+    padding: 2px 15px;
+  }
+
+  .navbar-nav > li > & {
+    border-top-right-radius: 3px;
+    border-top-left-radius: 3px;
+  }
+
+  > li > a {
     color: #ccc;
     padding-bottom: 3px;
     padding-top: 3px;
@@ -16,15 +60,45 @@
     }
   }
 
-  & > .divider {
+  > .divider {
     background-color: #000;
     border-bottom: 1px solid #434343;
     height: 2px;
     margin: 5px 0;
   }
+}
 
-  .navbar-utility .navbar-nav > li > & {
-    border-radius: 3px;
-    margin-top: 1px;
+.navbar-primary .dropdown-menu {
+  border: none;
+  border-top: 2px solid #c40022;
+  padding-top: 10px;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+
+  .dropdown-header,
+  > li > a {
+    padding: 2px 15px;
+  }
+
+  .dropdown-header {
+    font-size: 12px;
+    font-weight: normal;
+  }
+
+  > li > a {
+    color: #333;
+    font-family: @headings-font-family;
+    font-size: 16px;
+    font-weight: 600;
+    padding-bottom: 3px;
+    padding-top: 3px;
+    .font-smoothing;
+
+    &:hover,
+    &:focus {
+      background: #f5f5f5;
+      color: @navbar-default-link-active-color;
+      text-decoration: none;
+    }
   }
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -134,6 +134,17 @@
 @nav-tabs-active-link-bg: #fff;
 @nav-tabs-active-link-color: @text-color;
 
+// dropdowns
+@dropdown-bg: #fff;
+@dropdown-border: rgba(0,0,0,.15);
+@dropdown-fallback-border: #ccc;
+@dropdown-divider-bg: #e5e5e5;
+@dropdown-link-color: @link-color;
+@dropdown-link-hover-color: @link-color;
+@dropdown-link-hover-bg: @dropdown-bg;
+@dropdown-link-active-bg: @dropdown-bg;
+@dropdown-header-color: @gray;
+
 
 // CANON
 


### PR DESCRIPTION
The scope of this pr is to update default styles for dropdowns and accommodate any content we had in canon canon (captions).

Normally there are two styles of dropdowns in bootstrap, .dropdown-menu & .dropdown-inverse.dropdown-menu. I’ve added `.navbar-primary .dropdown-menu` to have the original primary nav dropdown style for those that need it.

Check it:

![image](https://cloud.githubusercontent.com/assets/399776/6198120/7ade31a6-b3a8-11e4-9d44-c33ebd5eec52.png)

![image](https://cloud.githubusercontent.com/assets/399776/6198126/8fa1ac58-b3a8-11e4-8aca-16e579e81de3.png)

![image](https://cloud.githubusercontent.com/assets/399776/6198128/9d1315de-b3a8-11e4-8b8a-a718d406115f.png)

Tiny note re: primary nav dropdown. I didn’t bother to fix positioning. I think I’d like to tackle that in another pr and maybe address the caret issue as well.
