### PR TITLE
feat(buttons): add .btn-login

### DIFF
--- a/docs/src/components/index.html
+++ b/docs/src/components/index.html
@@ -1,0 +1,32 @@
+---
+title: Canon Components
+description: Canon Components
+template: demo.html
+---
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="rs-main rs-panel">
+      <div class="panel panel-section">
+        <div class="panel-heading">
+          <h1 class="panel-title">Components</h1>
+        </div>
+
+        <div class="panel-body">
+          <h3>Buttons</h3>
+          <p>
+            <a class="btn btn-default">Click Me</a>
+            <a class="btn btn-primary">Something Important</a>
+            <a class="btn btn-info">Info Button</a>
+            <a class="btn btn-warning">Careful!</a>
+          </p>
+          <p>
+            In Canon, a red button is used for logging in, and not for dangerous
+            actions. Use <code>.btn .btn-login</code> for a login button.
+          </p>
+          <a class="btn btn-login">Log In</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -1,9 +1,14 @@
+.btn-login {
+  .button-variant(@btn-danger-color; @btn-danger-bg; @btn-danger-border);
+}
+
 .btn-default,
 .btn-primary,
 .btn-success,
 .btn-info,
 .btn-warning,
-.btn-danger {
+.btn-danger,
+.btn-login {
   border-radius: 3px;
   text-shadow: 0 1px rgba(0, 0, 0, 0.1);
 }
@@ -133,7 +138,8 @@
   }
 }
 
-.btn-danger {
+.btn-danger,
+.btn-login {
   background-color: #C40021;
   background-image: linear-gradient(to bottom, #D8002A, #C40021);
   box-shadow: inset 0px 1px 0px 0px rgba(255, 255, 255, .3),


### PR DESCRIPTION
The .btn-login class is used to improve the semantics of red buttons in
the design language of Canon. Red buttons are used for logging in in
Canon, as opposed to dangerous actions in Bootstrap. Canon-bootstrap
will have both as we are exploring new use cases for buttons at the same
time as supporting the Canon language.

This change also includes a component demo. The intent is if a new use
case for the framework doesn't fit well in the existing realistic demo,
you can put it by itself in the component demo.