### PR TITLE
Split out Canon-specific imports.

### DIFF
--- a/less/canon-bootstrap.less
+++ b/less/canon-bootstrap.less
@@ -1,27 +1,3 @@
-// External Dependencies
 @import 'bootstrap';
 @import 'font-awesome';
-
-// Variables and Mixins
-@import 'mixins';
-@import 'variables';
-@import 'fonts';
-
-// Base Elements
-@import 'base';
-
-// Components
-@import 'navbar';
-@import 'dropdowns';
-@import 'buttons';
-@import 'main';
-@import 'popover';
-@import 'tables';
-@import 'facet';
-@import 'forms';
-@import 'alerts';
-@import 'pagination';
-@import 'panels';
-@import 'progress-bars';
-@import 'tabs';
-@import 'tooltip';
+@import 'canon';

--- a/less/canon.less
+++ b/less/canon.less
@@ -1,0 +1,23 @@
+// Variables and Mixins
+@import 'mixins';
+@import 'variables';
+@import 'fonts';
+
+// Base Elements
+@import 'base';
+
+// Components
+@import 'navbar';
+@import 'dropdowns';
+@import 'buttons';
+@import 'main';
+@import 'popover';
+@import 'tables';
+@import 'facet';
+@import 'forms';
+@import 'alerts';
+@import 'pagination';
+@import 'panels';
+@import 'progress-bars';
+@import 'tabs';
+@import 'tooltip';


### PR DESCRIPTION
When using Canon Bootstrap with webpack, `canon-boostrap.less` caused issues by mixing external dependencies that need to be resolved from NPM or Bower and dependencies located in the main source tree. This PR moves local imports into `canon.less` and includes that file from within `canon-boostrap.less`. This enables:

1. Complete builds including dependencies using `canon-boostrap.less`.
2. Custom builds that don't include Bootstrap or Font Awesome using `canon.less`.