### PR TITLE
feat(gulp): add csslint for canon styling

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -6,9 +6,34 @@ var minifyCSS = require('gulp-minify-css');
 var less = require('gulp-less');
 var sourcemaps = require('gulp-sourcemaps');
 var concat = require('gulp-concat');
+var csslint = require('gulp-csslint');
+var data = require('gulp-data');
 var argv = require('yargs')
   .default('baseUri', '/')
   .argv;
+
+var customStyleDelimiter = '/* Include Canon */';
+var customStyleStartingLine = 0;
+var customStyleStartingLineReporter = function(file) {
+  file.csslint.results.forEach(function(result) {
+    var message, c = util.colors;
+    if (result.error.line >= customStyleStartingLine) {
+      message  = result.error;
+      util.log(
+        c.red('[') +
+        (
+          typeof message.line !== 'undefined' ?
+          c.yellow( 'L' + message.line ) +
+          c.red(':') +
+          c.yellow( 'C' + message.col )
+            :
+            c.yellow('GENERAL')
+        ) +
+        c.red('] ') +
+        message.message + ' ' + message.rule.desc + ' (' + message.rule.id + ')');
+    }
+  });
+};
 
 function error(e) {
   util.log(e.toString());
@@ -111,4 +136,21 @@ gulp.task('server', ['documentation'], function () {
 
   return gulp.src('docs/build')
     .pipe(webserver({ livereload: true }));
+});
+
+gulp.task('csslint', ['build'], function(){
+  gulp.src('build/css/canon-bootstrap.css')
+    .pipe(data(function(file) {
+      var content = String(file.contents);
+      var lines = content.split("\n");
+      for(var i = 0; i < lines.length; i++) {
+        if (lines[i].indexOf(customStyleDelimiter) > -1) {
+          customStyleStartingLine = i + 1;
+          break;
+        }
+      }
+      return content;
+    }))
+    .pipe(csslint())
+    .pipe(csslint.reporter(customStyleStartingLineReporter));
 });

--- a/less/canon-bootstrap.less
+++ b/less/canon-bootstrap.less
@@ -1,3 +1,4 @@
 @import 'bootstrap';
 @import 'font-awesome';
+/* Include Canon */
 @import 'canon';

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "del": "^0.1.3",
     "gulp": "^3.8.9",
     "gulp-concat": "^2.4.2",
+    "gulp-csslint": "^0.1.5",
+    "gulp-data": "^1.2.0",
     "gulp-less": "^1.3.6",
     "gulp-minify-css": "^0.3.11",
     "gulp-sourcemaps": "^1.2.4",


### PR DESCRIPTION
This PR adds a Gulp `csslint` task to run `canon-bootstrap.css` through CSSLint.

The Gulp task is not linked to the CI process, nor is a custom CSSLint ruleset yet defined (using defaults). Only infractions coming from Canon-specific custom styling is reported back from the Gulp task to avoid reporting infractions from Bootstrap (500+).

I opted to lint the compiled CSS instead of the raw Less so that developers are better exposed to the final output. In my experience, Less often results in more (e.g. nesting can make seriously long compound selectors) and tends to discourage developers from considering the efficiency of the compiled CSS. A tool like this should help keep us honest, and the product more performant.

Please review.