### PR TITLE
fix(main): remove padding from rs-content

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -59,8 +59,6 @@
 
 .rs-content {
   .clearfix;
-  padding: 0 @padding-base-horizontal*2 @padding-base-vertical*4 ;
-
 }
 
 .rs-control-bar {


### PR DESCRIPTION
In Canon, `.rs-content` relies on the optional use of `.rs-inner` to add padding when necessary. The padding specified in Canon Bootstrap was both the wrong size (24px) and placed on the wrong element entirely, so it was causing conflicts with Canon. This removes the padding to maintain consistent behavior with Canon.